### PR TITLE
fixes error message for GLEECBTC wallet.dat path

### DIFF
--- a/stats
+++ b/stats
@@ -129,7 +129,6 @@ outputstats ()
             GLEEC)
                 coinsutxoamount=$utxoamt
                 coinsntraddr=$kmdntrzaddr
-                coinwalletpath="${HOME}/${coin[3]}/wallets/wallet.dat"
                 ;;
             *)
                 coinsutxoamount=$utxoamt


### PR DESCRIPTION
works fine without the line that is removed.
`ls: cannot access '/home/user/.gleecbtc/wallets/wallet.dat': No such file or directory`